### PR TITLE
Add support for string parse callback, for optional string rewriting.

### DIFF
--- a/generic.jai
+++ b/generic.jai
@@ -156,7 +156,7 @@ json_write_json_value :: (builder: *String_Builder, using val: JSON_Value, inden
 		case JSON_Type.BOOLEAN;
 			append(builder, ifx boolean "true" else "false");
 		case JSON_Type.NUMBER;
-			print_item_to_builder(builder, number);
+                        print_item_to_builder(builder, number);
 		case JSON_Type.STRING;
 			json_append_escaped(builder, str);
 		case JSON_Type.ARRAY;
@@ -383,3 +383,4 @@ parse_object :: (str: string) -> result: JSON_Object, remainder: string, success
 
 #import "Compiler";
 #import "unicode_utils";
+#import "Math";

--- a/module.jai
+++ b/module.jai
@@ -139,7 +139,7 @@ expect_and_slice :: (str: string, expected: string) -> remainder: string, succes
 	return remainder, true;
 }
 
-parse_string :: (str: string) -> result: string, remainder: string, success: bool {
+parse_string :: (str: string, string_parse_callback : (s: string)->string = null) -> result: string, remainder: string, success: bool {
 	assert(str[0] == #char "\"", "Invalid string start %", str);
 	inside := advance(str);
 	needsUnescape := false;
@@ -155,12 +155,17 @@ parse_string :: (str: string) -> result: string, remainder: string, success: boo
 
 	length := inside.data - str.data - 1;
 	result := slice(str, 1, length);
+
 	if needsUnescape {
 		success: bool;
 		result, success = unescape(result);
 		if !success		return "", str, false;
 	} else {
 		result = copy_string(result);
+	}
+
+	if string_parse_callback != null {
+		result = string_parse_callback(result);
 	}
 
 	remainder := slice(str, length + 2, str.count - length - 2);

--- a/typed.jai
+++ b/typed.jai
@@ -4,12 +4,12 @@
 // All fields in the JSON that have no corresponding member in Type are ignored by default
 // but you can pass ignore_unknown = false to fail instead.
 //@Incomplete: The typed interface cannot yet parse into float members. (Because I haven’t needed it yet. 🙈) PRs welcome!
-json_parse_string :: (content: string, $T: Type, ignore_unknown := true, rename := rename_by_note) -> success: bool, T {
+json_parse_string :: (content: string, $T: Type, ignore_unknown := true, rename := rename_by_note, string_parse_callback : (s: string)->string = null) -> success: bool, T {
 	result: T;
 	if !content then return false, result;
 
 	info := type_info(T);
-	remainder, success := parse_value(content, cast(*u8)*result, info, ignore_unknown, "", rename=rename);
+	remainder, success := parse_value(content, cast(*u8)*result, info, ignore_unknown, "", rename=rename, string_parse_callback=string_parse_callback);
 	if !success		return false, result;
 
 	remainder = trim_left(remainder, WHITESPACE_CHARS);
@@ -21,7 +21,7 @@ json_parse_string :: (content: string, $T: Type, ignore_unknown := true, rename 
 	return true, result;
 }
 
-json_parse_file :: (filename: string, $T: Type, ignore_unknown := true, rename := rename_by_note) -> success: bool, T {
+json_parse_file :: (filename: string, $T: Type, ignore_unknown := true, rename := rename_by_note, string_parse_callback : (s: string)->string = null) -> success: bool, T {
 	file_data, success := read_entire_file(filename);
 	result: T;
 	if !success		{
@@ -33,7 +33,7 @@ json_parse_file :: (filename: string, $T: Type, ignore_unknown := true, rename :
 	if (context.log_level >= .VERBOSE) {
 		log("Read file: %", success);
 	}
-	success, result = json_parse_string(file_data, T, ignore_unknown, rename=rename);
+	success, result = json_parse_string(file_data, T, ignore_unknown, rename=rename, string_parse_callback);
 	return success, result;
 }
 
@@ -163,7 +163,7 @@ is_generic_json_value :: (info: *Type_Info) -> bool {
 	return info == type_info(JSON_Value);
 }
 
-parse_value :: (to_parse: string, slot: *u8, info: *Type_Info, ignore_unknown: bool, field_name: string, rename: Rename_Proc) -> remainder: string, success: bool {
+parse_value :: (to_parse: string, slot: *u8, info: *Type_Info, ignore_unknown: bool, field_name: string, rename: Rename_Proc, string_parse_callback: (s: string)->string = null) -> remainder: string, success: bool {
 	remainder := trim_left(to_parse, WHITESPACE_CHARS);
 	success := true;
 
@@ -255,7 +255,7 @@ parse_value :: (to_parse: string, slot: *u8, info: *Type_Info, ignore_unknown: b
 				remainder, success = parse_enum_string(remainder, value_slot, info_enum);
 			} else {
 				value: string;
-				value, remainder, success = parse_string(remainder);
+				value, remainder, success = parse_string(remainder, string_parse_callback=string_parse_callback);
 				stored := false;
 				defer if !stored	free(value);
 				if success && slot {
@@ -283,7 +283,7 @@ parse_value :: (to_parse: string, slot: *u8, info: *Type_Info, ignore_unknown: b
 					value, remainder, success = parse_array(remainder);
 					json_set(cast(*JSON_Value)value_slot, value);
 				} else {
-					remainder, success = parse_array(remainder, value_slot, cast(*Type_Info_Array) value_info, ignore_unknown, rename=rename);
+					remainder, success = parse_array(remainder, value_slot, cast(*Type_Info_Array) value_info, ignore_unknown, rename=rename, string_parse_callback=string_parse_callback);
 				}
 			}
 		case #char "{";
@@ -295,10 +295,10 @@ parse_value :: (to_parse: string, slot: *u8, info: *Type_Info, ignore_unknown: b
 			if success {
 				if is_generic {
 					value := New(JSON_Object);
-					<<value, remainder, success = parse_object(remainder);
+					<<value, remainder, success = parse_object(remainder); // , string_parse_callback=string_parse_callback);
 					json_set(cast(*JSON_Value)value_slot, value);
 				} else {
-					remainder, success = parse_object(remainder, value_slot, cast(*Type_Info_Struct) value_info, ignore_unknown, rename=rename);
+					remainder, success = parse_object(remainder, value_slot, cast(*Type_Info_Struct) value_info, ignore_unknown, rename=rename, string_parse_callback=string_parse_callback);
 				}
 			}
 		case;
@@ -421,7 +421,7 @@ parse_enum_string :: (str: string, slot: *u8, info_enum: *Type_Info_Enum) -> rem
     return remainder, success;
 }
 
-parse_array :: (str: string, slot: *u8, info: *Type_Info_Array, ignore_unknown: bool, rename: Rename_Proc) -> remainder: string, success: bool {
+parse_array :: (str: string, slot: *u8, info: *Type_Info_Array, ignore_unknown: bool, rename: Rename_Proc, string_parse_callback: (s: string)->string = null) -> remainder: string, success: bool {
 	element_size: int;
 	stride: int;
 	if slot {
@@ -461,7 +461,7 @@ parse_array :: (str: string, slot: *u8, info: *Type_Info_Array, ignore_unknown: 
 			}
 
 			success: bool;
-			remainder, success = parse_value(remainder, element_data, info.element_type, ignore_unknown, "", rename=rename);
+			remainder, success = parse_value(remainder, element_data, info.element_type, ignore_unknown, "", rename=rename, string_parse_callback=string_parse_callback);
 			if !success	return remainder, false;
 
 			array.count += 1;
@@ -481,7 +481,7 @@ parse_array :: (str: string, slot: *u8, info: *Type_Info_Array, ignore_unknown: 
 	} else {
 		while true {
 			success: bool;
-			remainder, success = parse_value(remainder, null, null, ignore_unknown, "", rename=rename);
+			remainder, success = parse_value(remainder, null, null, ignore_unknown, "", rename=rename, string_parse_callback=string_parse_callback);
 			if !success	return remainder, false;
 
 			remainder = trim_left(remainder, WHITESPACE_CHARS);
@@ -517,7 +517,7 @@ fill_member_table :: (table: *Table(string, Member_Offset), info: *Type_Info_Str
 }
 
 
-parse_object :: (str: string, slot: *u8, info: *Type_Info_Struct, ignore_unknown: bool, rename: Rename_Proc) -> remainder: string, success: bool {
+parse_object :: (str: string, slot: *u8, info: *Type_Info_Struct, ignore_unknown: bool, rename: Rename_Proc, string_parse_callback: (s: string)->string = null) -> remainder: string, success: bool {
 	assert(str[0] == #char "{", "Invalid object start %", str);
 	remainder := advance(str);
 	remainder = trim_left(remainder, WHITESPACE_CHARS);
@@ -539,7 +539,7 @@ parse_object :: (str: string, slot: *u8, info: *Type_Info_Struct, ignore_unknown
 
 		key: string;
 		success: bool;
-		key, remainder, success = parse_string(remainder);
+		key, remainder, success = parse_string(remainder, string_parse_callback);
 		if !success		return remainder, false;
 		defer free(key);
 
@@ -559,7 +559,7 @@ parse_object :: (str: string, slot: *u8, info: *Type_Info_Struct, ignore_unknown
 		if remainder[0] != #char ":"	return remainder, false;
 		remainder = advance(remainder);
 		remainder = trim_left(remainder, WHITESPACE_CHARS);
-		remainder, success = parse_value(remainder, member_slot, member_info, ignore_unknown, key, rename);
+		remainder, success = parse_value(remainder, member_slot, member_info, ignore_unknown, key, rename, string_parse_callback);
 		if !success		return remainder, false;
 
 		remainder = trim_left(remainder, WHITESPACE_CHARS);


### PR DESCRIPTION
This patch allows optionally providing a callback function to `parse_json_file` or `parse_json_string` for the purposes of rewriting a string as it is being loaded. The main use case I have for this is to be able to provide, in a JSON file, variable names which then get interpolated by the callback. 

At the moment this is only written with typed use in mind, because I don't use the untyped functionality.

Obviously this is a rare use case, but I figured I'd submit the patch and see if it's sufficiently useful to be welcome ─ if it isn't, I may revert to the slower but more generic solution of either interpolating in the string before JSON parsing, or else "walking" the object after it has been populated by `parse_json_file` etc. However, I do hope it doesn't have to come to that. :-)