### PR TITLE
Beta 0.1.080 fixes continued

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # JSON serialization / deserialization module for Jai
 
-*Attention: This version requires Jai beta 0.1.050! Please use [the 0.1.049 branch](https://github.com/rluba/jason/tree/release/beta_0.1.049) for older betas.*
+*Attention: This version requires Jai beta 0.1.080!*
 
 This module offers two interfaces:
 * one uses a "generic tree" built from `JSON_Value`

--- a/typed.jai
+++ b/typed.jai
@@ -381,7 +381,7 @@ parse_enum_string :: (str: string, slot: *u8, info_enum: *Type_Info_Enum) -> rem
     int_value: s64;
     if info_enum.enum_type_flags & .FLAGS {
         parsed_count := 0;
-        values := split(value, "|");
+        values := split(value, "|",, temp);
 
         for v: values {
             name := normalize_enum_value(v);

--- a/typed.jai
+++ b/typed.jai
@@ -186,7 +186,7 @@ parse_value :: (to_parse: string, slot: *u8, info: *Type_Info, ignore_unknown: b
 			if teaser.count > 50	teaser.count = 50;
             builder: String_Builder;
             print_type_to_builder(*builder, info);
-            type_name := builder_to_string(*builder, allocator = temp);
+            type_name := builder_to_string(*builder,, allocator = temp);
 			log_error("Cannot parse % value into type \"%\". Remaining input is: %…", expected_type, type_name, teaser);
 			return null, false, false, value_info;
 		}
@@ -221,7 +221,7 @@ parse_value :: (to_parse: string, slot: *u8, info: *Type_Info, ignore_unknown: b
                 } else {
                     builder: String_Builder;
                     print_type_to_builder(*builder, info);
-                    type_name := builder_to_string(*builder, allocator = temp);
+                    type_name := builder_to_string(*builder,, allocator = temp);
 					log_error("Got NULL value for non-pointer type \"%\" of field \"%\". Keeping default value instead.", type_name, field_name);
 				}
 			}


### PR DESCRIPTION
*N.B. I've rolled in @SogoCZE's commit from #18 here, since those changes are required to compile with beta 0.1.080*

As my commit message says:
- Revert to temp allocator for String.split call in parse_enum_string. String.split was changed *without rename or deprecation* to default context allocator in this release, which (without this change) would make this a leaked default contect allocation.
- Update required beta version in readme, since the new code relies on the double-comma context parameter feature added in beta 0.1.080. (I've also removed the note about the 0.1.049 branch, since it doesn't seem to exist. You may or may not wish to add a branch for betas 0.1.050-079, but it's not something I can do from here.)