### PR TITLE
Update typed.jai

### DIFF
--- a/typed.jai
+++ b/typed.jai
@@ -490,6 +490,7 @@ parse_array :: (str: string, slot: *u8, info: *Type_Info_Array, ignore_unknown: 
             }
 
             memcpy(slot, array.data, array.count * element_size);
+            free(array.data);
         }
 	} else {
 		while true {


### PR DESCRIPTION
I'm a noob in this, so maybe this is wrong. But if we are not giving the user the ownership of the memory allocated by the dynamic array, which is the case of the fixed size array, shouldn't we just free it after coping it's elements?